### PR TITLE
Add support for compiling on Android 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,12 @@ description = "High-performance URL preview generator for messaging and social m
 license = "MIT"
 repository = "https://github.com/ZhangHanDong/url-preview"
 
+[features]
+default = ["reqwest/default"]
+
 [dependencies]
 tokio = { version = "1.28", features = ["full"] }
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.11", features = ["json"], default-features = false }
 scraper = "0.17"
 url = "2.4"
 thiserror = "1.0"


### PR DESCRIPTION
by allowing to disable reqwest's default features. The blocker is that request by default pulls in `openssl-sys` which isn't supported for android compiling. But reqwest compiles perfectly fine for android if default-features are disabled. To allow url-preview the same, we must pass through that default-disabling and enabling. Which is what this PR does.

With this you can now:
```

#   ----   ANDROID
[target.'cfg(target_os = "android")'.dependencies]
url-preview = { version = "*",  default-features = false }

# ---- non Android
[target.'cfg(not(target_os = "android"))'.dependencies]
url-preview = { version = "*", default-features = true }
```